### PR TITLE
Fixes locale configuration error

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -14,7 +14,9 @@ if node[:locales]
   node[:locales].each do |locale|
     bash "adding #{locale} to /var/lib/locales/supported.d/local" do
       user 'root'
-      echo locale >> "/var/lib/locales/supported.d/local"
+      code <<-EOC
+        echo locale >> "/var/lib/locales/supported.d/local"
+      EOC
     end
   end
   bash "Including new locales" do


### PR DESCRIPTION
The command needs to be run as shell, otherwise it tries to call locale.>> and fails with:

`ERROR: undefined method '>>' for "pt_BR.UTF-8 UTF-8":String`
